### PR TITLE
Prefer DV::sync to manual syncing dance

### DIFF
--- a/kokkos/fem/verify_solution.hpp
+++ b/kokkos/fem/verify_solution.hpp
@@ -55,8 +55,13 @@ struct err_info {
 template<typename VectorType>
 int
 verify_solution(const simple_mesh_description<typename VectorType::GlobalOrdinalType>& mesh,
-                const VectorType& x, double tolerance, bool verify_whole_domain = false)
+                VectorType& x, // can't be const, need to sync
+                double tolerance, bool verify_whole_domain = false)
 {
+
+  // make sure host-side x is up to date
+  x.coefs.template sync<typename decltype(x.coefs)::t_host::device_type>();
+
   typedef typename VectorType::GlobalOrdinalType GlobalOrdinal;
   typedef typename VectorType::ScalarType Scalar;
 


### PR DESCRIPTION
This fixes two problems:

* The modified `x` from `cg_solve` was never synced back to the host in verify_solution.
* You can't call `modify<Dev>` on e.g. `x` at the beginning of `cg_solve` because the Vector ctor modifies it on the host, so both host and device modify flags will be set. We can fix this by using the `sync` function rather than copying the views manually.